### PR TITLE
Invalid gemspec

### DIFF
--- a/action_mailer_cache_delivery.gemspec
+++ b/action_mailer_cache_delivery.gemspec
@@ -4,6 +4,7 @@ require "action_mailer_cache_delivery/version"
 
 Gem::Specification.new do |s|
   s.name        = "action_mailer_cache_delivery"
+  s.author      = "ngty77@gmail.com"
   s.version     = ActionMailerCacheDelivery::VERSION
   s.summary     = %q{Gem-ized version of action_mailer_cache_delivery}
   s.description = %q{It's a gem}


### PR DESCRIPTION
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  authors may not be empty
